### PR TITLE
Update introduction.md, schema_builder.md, table_builder.md

### DIFF
--- a/content/docs/migrations/introduction.md
+++ b/content/docs/migrations/introduction.md
@@ -192,7 +192,7 @@ You can alter an existing database table using the `schema.alterTable` method. T
 
 ```ts
 export default class extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.alterTable('user', (table) => {
       table.dropColumn('name')
@@ -211,7 +211,7 @@ You can rename the table using the `schema.renameTable`. The method accepts the 
 ```ts
 export default class extends BaseSchema {
   // highlight-start
-  up() {
+  async up() {
     this.schema.renameTable('user', 'app_users')
   }
   // highlight-end
@@ -223,7 +223,7 @@ You can drop the table using the `schema.dropTable`. The method accepts the tabl
 ```ts
 export default class extends BaseSchema {
   // highlight-start
-  down() {
+  async down() {
     this.schema.dropTable('users')
   }
   // highlight-end
@@ -254,7 +254,7 @@ We migrate the emails from the `users` table to the `user_emails` table in the f
 
 ```ts
 export default class extends BaseSchema {
-  up() {
+  async up() {
     this.schema.createTable('user_emails', (table) => {
       // table columns
     })

--- a/content/docs/migrations/schema_builder.md
+++ b/content/docs/migrations/schema_builder.md
@@ -8,7 +8,7 @@ You can access the schema builder instance using the `this.schema` property in y
 import { BaseSchema } from '@adonisjs/lucid/schema'
 
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     console.log(this.schema)
   }
 }
@@ -19,7 +19,7 @@ Creates a new database table. The method accepts the table name and a callback t
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.createTable('users', (table) => {
       table.increments()
@@ -37,7 +37,7 @@ Create the PostgreSQL schema. It accepts the schema name.
 
 ```ts
 class FoundationSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.createSchema('public')
     // highlight-end
@@ -50,7 +50,7 @@ Select a SQL table to alter its columns. The method accepts the table name and a
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.alterTable('user', (table) => {
       /**
@@ -74,7 +74,7 @@ Rename a table. The method accepts the existing table name as the first argument
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.renameTable('user', 'app_users')
     // highlight-end
@@ -87,7 +87,7 @@ Drop an existing SQL table. The method accepts the table name as the only argume
 
 ```ts
 class UserSchema extends BaseSchema {
-  down() {
+  async down() {
     // highlight-start
     this.schema.dropTable('users')
     // highlight-end
@@ -100,7 +100,7 @@ Similar to the `dropTable` method, but conditionally drop the table if it exists
 
 ```ts
 class UserSchema extends BaseSchema {
-  down() {
+  async down() {
     // highlight-start
     this.schema.dropTableIfExists('users')
     // highlight-end
@@ -113,7 +113,7 @@ Drop an existing PostgreSQL schema. The method accepts the schema name as the on
 
 ```ts
 class FoundationSchema extends BaseSchema {
-  down() {
+  async down() {
     // highlight-start
     this.schema.dropSchema('public')
     // highlight-end
@@ -126,7 +126,7 @@ Similar to the `dropSchema` method, but conditionally drop the schema if it exis
 
 ```ts
 class FoundationSchema extends BaseSchema {
-  down() {
+  async down() {
     // highlight-start
     this.schema.dropSchemaIfExists('public')
     // highlight-end
@@ -139,7 +139,7 @@ Run a SQL query from the raw string. Unlike the [raw query builder](../query_bui
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema
       .raw("SET sql_mode='TRADITIONAL'")
@@ -158,7 +158,7 @@ Specify the schema to select when running the SQL DDL statements. The method acc
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema
       .withSchema('public')

--- a/content/docs/migrations/table_builder.md
+++ b/content/docs/migrations/table_builder.md
@@ -6,7 +6,7 @@ You get access to the table builder instance by calling one of the following sch
 
 ```ts
 class UserSchema extends BaseSchema {
-  up() {
+  async up() {
     // highlight-start
     this.schema.createTable('users', (table) => {
       console.log(table) // 👈 Table builder
@@ -83,7 +83,7 @@ this.schema.createTable('users', (table) => {
 Adds a `bigint` column in MYSQL and PostgreSQL. For all other database drivers, it defaults to a normal integer.
 
 :::note
-BigInt column values are returned as a string in query results. 
+BigInt column values are returned as a string in query results.
 :::
 
 ```ts
@@ -336,11 +336,11 @@ Make sure also to create the UUID extension for PostgreSQL. You can also do it i
 import BaseSchema from '@ioc:Adonis/Lucid/Schema'
 
 export default class SetupExtensions extends BaseSchema {
-  up() {
+  async up() {
     this.schema.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
   }
 
-  down() {
+  async down() {
     this.schema.raw('DROP EXTENSION IF EXISTS "uuid-ossp"')
   }
 }
@@ -523,7 +523,7 @@ this.schema.alterTable('posts', (table) => {
 
 ## Chainable methods
 
-Following is the list of methods you can chain on the schema building methods as modifiers to the column. 
+Following is the list of methods you can chain on the schema building methods as modifiers to the column.
 
 ### alter
 
@@ -585,7 +585,7 @@ this.schema.table('users', (table) => {
 ```
 
 ## references
-Define the column that the current column references as a foreign key. 
+Define the column that the current column references as a foreign key.
 
 ```ts
 this.schema.table('posts', (table) => {
@@ -637,14 +637,14 @@ this.schema.table('posts', (table) => {
 ```
 
 ## defaultTo
-Define the default value for the column to be used during the insert. 
+Define the default value for the column to be used during the insert.
 
 In MSSQL a constraintName option may be passed to ensure a specific constraint name:
 
 ```ts
 this.schema.table('posts', (table) => {
   table.boolean('is_published').defaultTo(false)
-  
+
   // For MSSQL
   table
     .boolean('is_published')
@@ -653,7 +653,7 @@ this.schema.table('posts', (table) => {
 ```
 
 ## unsigned
-Mark the current column as unsigned. 
+Mark the current column as unsigned.
 
 ```ts
 this.schema.table('posts', (table) => {
@@ -669,7 +669,7 @@ this.schema.table('posts', (table) => {
 Mark the current column as NOT nullable.
 
 :::note
-Consider using [dropNullable](#dropnullable) method when altering the column. 
+Consider using [dropNullable](#dropnullable) method when altering the column.
 :::
 
 ```ts
@@ -682,7 +682,7 @@ this.schema.table('users', (table) => {
 Mark the current column as nullable.
 
 :::note
-Consider using [setNullable](#setnullable) method when altering the column. 
+Consider using [setNullable](#setnullable) method when altering the column.
 :::
 
 ```ts


### PR DESCRIPTION
This pull request addresses an issue where the `async` keyword was missing from the `up` and `down` methods in migrations documentation .

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
