### PR TITLE
fix: broken external naming strategy links and internal many to many link

### DIFF
--- a/content/docs/models/model_factories.md
+++ b/content/docs/models/model_factories.md
@@ -167,7 +167,7 @@ const user = await UserFactory.with('posts', 2, (post) => post.with('comments', 
 
 ### Pivot attributes
 
-When creating a [many to many](relationships.md#manytomany) relationship, you can define the attributes for the pivot table using the `pivotAttributes` method.
+When creating a [many to many](./relationships.md#manytomany) relationship, you can define the attributes for the pivot table using the `pivotAttributes` method.
 
 In the following example, the `User` model has a many to many relationship with the `Team` model and we define the user role within a given team.
 

--- a/content/docs/models/naming_strategy.md
+++ b/content/docs/models/naming_strategy.md
@@ -4,7 +4,7 @@ summary: Reference guide to naming strategies in Lucid ORM
 
 # Naming Strategy
 
-The [NamingStrategy](https://github.com/adonisjs/lucid/blob/develop/src/Orm/NamingStrategies/SnakeCase.ts) class allows you to override the conventional names used by the ORM. For example: Instead of using the `snake_case` for the column names, you can provide your own custom `camelCase` naming strategy.
+The [NamingStrategy](https://github.com/adonisjs/lucid/blob/develop/src/orm/naming_strategies/camel_case.ts) class allows you to override the conventional names used by the ORM. For example: Instead of using `snake_case` for your column names, you can provide your own custom `camelCase` naming strategy.
 
 Every naming strategy must implement the `NamingStrategyContract` contract and define all the required methods.
 

--- a/content/docs/models/relationships.md
+++ b/content/docs/models/relationships.md
@@ -351,7 +351,7 @@ Remember, if you intend to use camelCase for your foreign key definition, keep i
 
 ### Custom pivot table
 
-The default value for the pivot table name is computed by [combining](https://github.com/adonisjs/lucid/blob/develop/src/Orm/NamingStrategies/SnakeCase.ts#L73) the **parent model name** and the **related model name**. However, you can also define a custom pivot table.
+The default value for the pivot table name is computed by [combining](https://github.com/adonisjs/lucid/blob/develop/src/orm/naming_strategies/camel_case.ts#L74) the **parent model name** and the **related model name**. However, you can also define a custom pivot table.
 
 ```ts
 @manyToMany(() => Skill, {


### PR DESCRIPTION
### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey guys! 

Came across a few broken links, listed below. The naming strategy broken links were attempting to point to the `snake_case` naming strategy, but since `camelCase` is now the default I went ahead and used `camelCase` for the fixed links, hope that's okay. Also, tweaked the verbiage ever so slightly on the first paragraph of the naming strategy doc to get rid of the double "the"

Fixed
- Broken external "NamingStrategy" link, [here](https://lucid.adonisjs.com/docs/model-naming-strategy). 
- Broken external "combining" link, [here](https://lucid.adonisjs.com/docs/relationships#custom-pivot-table).
- Broken internal "many to many" link, [here](https://lucid.adonisjs.com/docs/model-factories#pivot-attributes)

Tweaked
- Verbiage slightly on the first paragraph of the Naming Strategy page, [here](https://lucid.adonisjs.com/docs/model-naming-strategy). 
  - From: "For example: Instead of using the snake_case for the column names, you can provide your own custom camelCase naming strategy."
  - To: "For example: Instead of using snake_case for your column names, you can provide your own custom camelCase naming strategy."

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
