### PR TITLE
fix(hooks): correction of the argument structure in the example of th…

### DIFF
--- a/content/docs/models/hooks.md
+++ b/content/docs/models/hooks.md
@@ -203,10 +203,10 @@ import type { ModelQueryBuilderContract } from '@adonisjs/lucid/types/model'
 
 export default class User extends BaseModel {
   @beforePaginate()
-  static ignoreDeleted ([
+  static ignoreDeleted (
     countQuery: ModelQueryBuilderContract<typeof User>,
     query: ModelQueryBuilderContract<typeof User>,
-  ]) {
+  ) {
     query.whereNull('is_deleted')
     countQuery.whereNull('is_deleted')
   }

--- a/content/docs/models/hooks.md
+++ b/content/docs/models/hooks.md
@@ -205,7 +205,7 @@ export default class User extends BaseModel {
   @beforePaginate()
   static ignoreDeleted (
     countQuery: ModelQueryBuilderContract<typeof User>,
-    query: ModelQueryBuilderContract<typeof User>,
+    query: ModelQueryBuilderContract<typeof User>
   ) {
     query.whereNull('is_deleted')
     countQuery.whereNull('is_deleted')


### PR DESCRIPTION
correction of the argument structure in the example of the ignoreDeleted method used for the beforePagninate hook to ensure correct use of parameters.

### 🔗 Linked issue
#29

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Modification of the example of the ignoreDeleted function by not passing the parameters via an array but rather by passing the parameters one by one.
This will prevent errors when trying to use the beforePaginate hook. 

Resolves #29

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
