### PR TITLE
feat: add transaction example with customer as a parameter

### DIFF
--- a/content/docs/guides/transactions.md
+++ b/content/docs/guides/transactions.md
@@ -170,6 +170,21 @@ await db.transaction(async (trx) => {
 // highlight-end
 ```
 
+It is possible to give the transaction as a customer, here is a simple example.
+
+```ts
+import User from '#models/user'
+import db from '@adonisjs/lucid/services/db'
+
+// highlight-start
+await db.transaction(async (trx) => {
+  const user = await User.create({ 
+    username: 'virk' 
+  }, { client: trx })
+})
+// highlight-end
+```
+
 ### Model query builder
 
 Just like the standard query builder, you can also pass the transaction to the model query builder.


### PR DESCRIPTION
### 🔗 Linked issue

No issue

### ❓ Type of change
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

I've added a presentation of how to give the transaction as a client via the builder.
As I'm not documented, several people came to ask me privately how they could do this, so I took the initiative of adding this little piece of code.
