### PR TITLE
Removed outdated paginator naming strategy solution

### DIFF
--- a/content/docs/guides/pagination.md
+++ b/content/docs/guides/pagination.md
@@ -149,26 +149,3 @@ posts.namingStrategy = {
 
 return posts.toJSON()
 ```
-
-You can also assign a custom naming strategy to the `SimplePaginator` class constructor to override it globally inside a [service provider](https://docs.adonisjs.com/guides/service-providers)
-
-```ts
-import db from '@adonisjs/lucid/services/db'
-import type { ApplicationService } from '@adonisjs/core/types'
-
-export default class AppProvider {
-  constructor(protected app: ApplicationService) {}
-
-  async ready() {
-    // highlight-start
-    db.SimplePaginator.namingStrategy = {
-      paginationMetaKeys() {
-        return {
-          // ... same as above
-        }
-      },
-    }
-    // highlight-end
-  }
-}
-```


### PR DESCRIPTION
### 🔗 Linked issue

Fix #24 

### ❓ Type of change

Documented solution does not work anymore. 

the 'SimplePaginator' property [was removed](https://github.com/adonisjs/lucid/commit/50b098b15cbffd17d7aad41b059617bfeafd2606#diff-dd6241447ed15d4067fc846831102d2082e7a797d8421ab43ee2c89d61c3e2f0L63) from the 'Database' class.