### PR TITLE
docs(migrations): fix colon spacing in migration commands

### DIFF
--- a/content/docs/migrations/introduction.md
+++ b/content/docs/migrations/introduction.md
@@ -106,7 +106,7 @@ node ace migration:rollback --batch=0
 node ace migration:rollback --batch=1
 ```
 
-The `migration:reset` command is basically an alias for `migration:rollback --batch=0`. This will rollback all of your application's migrations :
+The `migration:reset` command is basically an alias for `migration:rollback --batch=0`. This will rollback all of your application's migrations:
 
 ```sh
 node ace migration:reset


### PR DESCRIPTION
Corrected spacing between word and colon in migration command examples.