### PR TITLE
docs(migrations): correct wording from 'configuration' to 'configure'

### DIFF
--- a/content/docs/migrations/introduction.md
+++ b/content/docs/migrations/introduction.md
@@ -431,7 +431,7 @@ Returns the current `status` of the migrator. It will always be one of the follo
 
 ## Migrations config
 
-The `migration` object defined on every database connection is used to configuration the migration system of Lucid. Following is the list of available options.
+The `migration` object defined on every database connection is used to configure the migration system of Lucid. Following is the list of available options.
 
 ```ts
 {


### PR DESCRIPTION
Word variant fixed for better flow.