### PR TITLE
docs(migrations): fix typo "command" to "commands" for plural agreement

### DIFF
--- a/content/docs/migrations/introduction.md
+++ b/content/docs/migrations/introduction.md
@@ -145,7 +145,7 @@ node ace migration:fresh --seed
 
 :::warning
 
-`migration:fresh` and `db:wipe` commands will drop all database tables. These command should be used with caution when developing on a database that is shared with other applications.
+`migration:fresh` and `db:wipe` commands will drop all database tables. These commands should be used with caution when developing on a database that is shared with other applications.
 
 :::
 


### PR DESCRIPTION
It refers to two commands, so it should be: "These commands" refers to both `migration:fresh` and `DB:wipe` - not just one command.