### PR TITLE
feat: natural sort option on seeders

### DIFF
--- a/content/docs/guides/seeders.md
+++ b/content/docs/guides/seeders.md
@@ -156,13 +156,15 @@ The configuration for seeders is stored inside the `config/database.ts` file und
 #### paths
 
 Define the paths for loading the database seeder files. You can also define a path to an installed package.
+And you can define naturalSort, which sorts the seeders in a natural order (e.g., `1`, `2`, `10` instead of `1`, `10`, `2`).
 
 ```ts
 {
   mysql: {
     client: 'mysql2',
     seeders: {
-      paths: ['./database/seeders', '@somepackage/seeders-dir']
+      paths: ['./database/seeders', '@somepackage/seeders-dir'],
+      naturalSort: true, // Optional, defaults to false
     }
   }
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seeders with a number above 9 start over when you launch the seeders, so I added the same functionality as migrations. I added an optional naturalSort.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion. (https://github.com/adonisjs/lucid/pull/1120)
- [X] I have updated the documentation accordingly.
