### PR TITLE
feat: add connection pooling section

### DIFF
--- a/content/docs/guides/installation.md
+++ b/content/docs/guides/installation.md
@@ -199,6 +199,56 @@ const dbConfig = defineConfig({
 })
 ```
 
+## Connection pooling
+
+[Connection pooling](https://en.wikipedia.org/wiki/Connection_pool) is a standard practice of maintaining minimum and maximum connections with the database server.
+
+The **minimum connections** are maintained for improving the application performance. Since establishing a new connection is an expensive operation, it is always recommended to have a couple of connections ready to execute the database queries.
+
+The **maximum connections** are defined to ensure that your application doesn't overwhelm the database server with too many concurrent connections.
+
+Lucid will queue new queries when the pool is full and waits for the pool to have free resources until the configured timeout. The default timeout is set to **60 seconds** and can be configured using the `pool.acquireTimeoutMillis` property.
+
+```ts
+{
+  postgres: {
+    client: 'pg',
+    connection: {},
+    // highlight-start
+    pool: {
+      acquireTimeoutMillis: 60 * 1000,
+    }
+    // highlight-end
+  }
+}
+```
+
+:::tip
+
+Bigger the pool size, the better the performance is a misconception. We recommend you read this [document](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) to understand how the smaller pool size can boost the application performance.
+
+:::
+
+You can configure the pool settings for a given connection inside the `config/database.ts` file.
+
+```ts
+{
+  connections: {
+    postgres: {
+      client: 'pg',
+      connection: {
+      },
+      // highlight-start
+      pool: {
+        min: 2,
+        max: 20,
+      },
+      // highlight-end
+    },
+  }
+}
+```
+
 ## Basic usage
 
 Once you have configured Lucid, you can start using the Database query builder to create and execute SQL queries. In the following code examples, we perform CRUD operations on the `posts` table.


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the AdonisJS v5 docs, there was a helpful section about [connection pooling](https://github.com/adonisjs/v5-docs/blob/3979a79c9d6f9c4bf499dc38334a546a3309475c/content/guides/database/introduction.md?plain=1#L284), with a link that explains the pool sizing.

I've just added the same section and checked that the examples are correct with the current Lucid version.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
