### PR TITLE
Update documentation for methods parameters

### DIFF
--- a/content/docs/relationships/has_many.md
+++ b/content/docs/relationships/has_many.md
@@ -291,20 +291,20 @@ await user.related('posts').updateOrCreate(
 
 ### fetchOrCreateMany and updateOrCreateMany
 
-Batch variants that work the same way as their single-row counterparts. Both accept a predicate key (or array of keys) that identifies each row, plus an array of rows to sync.
+Batch variants that work the same way as their single-row counterparts. Both accept an array of rows to sync, plus a predicate key (or array of keys) that identifies each row.
 
 ```ts
 // Ensure a tag exists for every slug, inserting missing ones
-await project.related('tags').fetchOrCreateMany('slug', [
+await project.related('tags').fetchOrCreateMany([
   { slug: 'alpha', label: 'Alpha' },
   { slug: 'beta', label: 'Beta' },
-])
+], 'slug'), 
 
 // Update label on existing tags or insert new rows
-await project.related('tags').updateOrCreateMany('slug', [
+await project.related('tags').updateOrCreateMany([
   { slug: 'alpha', label: 'Alpha (updated)' },
   { slug: 'beta', label: 'Beta (updated)' },
-])
+], 'slug')
 ```
 
 For both batch variants, the predicate is combined with the relationship's foreign key automatically. You do not need to include the foreign key in the payload or the predicate; Lucid sets it from the parent.


### PR DESCRIPTION
Clarified the order of parameters in the documentation for fetchOrCreateMany and updateOrCreateMany methods.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

### ❓ Type of change

- [ x ] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Fix order parameters in doc.

Ref type: https://github.com/adonisjs/lucid/blob/1a8817887fa1832b32100fecc999f27464e79866/src/types/relations.ts#L685

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ x ] I have updated the documentation accordingly.
